### PR TITLE
Add configure & fetchstyle plugins to example app

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
     alias(libs.plugins.android.library)
 
     alias(libs.plugins.android.application).apply(false)
+    alias(libs.plugins.automattic.configure).apply(false)
+    alias(libs.plugins.automattic.fetchstyle).apply(false)
     alias(libs.plugins.automattic.publishToS3).apply(false)
     alias(libs.plugins.kotlin.android).apply(false)
     alias(libs.plugins.kotlin.android.extensions).apply(false)

--- a/example/settings.gradle.kts
+++ b/example/settings.gradle.kts
@@ -1,10 +1,16 @@
 val catalogVersion: String? by settings
 pluginManagement {
     repositories {
-        maven {
-            url = uri("https://a8c-libs.s3.amazonaws.com/android")
-            content {
+        exclusiveContent {
+            forRepository {
+                maven {
+                    url = uri("https://a8c-libs.s3.amazonaws.com/android")
+                }
+            }
+            filter {
                 includeGroup("com.automattic.android")
+                includeGroup("com.automattic.android.configure")
+                includeGroup("com.automattic.android.fetchstyle")
                 includeGroup("com.automattic.android.publish-to-s3")
             }
         }


### PR DESCRIPTION
I forgot to include the `configure` & `fetchstyle` plugins in the `example` app in https://github.com/Automattic/android-dependency-catalog/pull/4 which is required for dependency caching. I've addressed the issue in this PR as well as switched the plugin repository syntax to `exclusiveContent` which is more secure because it doesn't allow our plugins to be fetched from anywhere else.

@ParaskP7 Thank you for the [reminder](https://github.com/Automattic/android-dependency-catalog/pull/4#issuecomment-1204904001)!

_P.S:_ I don't think it's worth doing a release just for this since the dependency caching is not fully utilized yet. I am sure we'll have another dependency update soon and this change can be shipped with that.

_P.S.2:_ Since this change is only concerning the example app, a new release doesn't impact the clients directly. However, a new tag will trigger the CI job that updates the dependency cache. Not a very important point, but I wanted to clarify how this change is connected to the releases.