### PR TITLE
Add androidx security-crypto library

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -26,6 +26,7 @@ androidx-preference = "1.1.1"
 androidx-recyclerview = "1.2.1"
 androidx-recyclerview-selection = "1.1.0"
 androidx-room = "2.4.2"
+androidx-security-crypto = "1.0.0"
 androidx-test-core = "1.4.0"
 androidx-test-espresso = "3.4.0"
 androidx-test-ext-junit = "1.1.3"
@@ -123,6 +124,7 @@ androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref =
 androidx-room-ktx = { module = "androidx.room:room-ktx", version.ref = "androidx-room" }
 androidx-room-runtime = { module = "androidx.room:room-runtime", version.ref = "androidx-room" }
 androidx-room-testing = { module = "androidx.room:room-testing", version.ref = "androidx-room" }
+androidx-security-crypto = { module = "androidx.security:security-crypto", version.ref = "androidx-security-crypto" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test-core" }
 androidx-test-espresso-contrib = { module = "androidx.test.espresso:espresso-contrib", version.ref = "androidx-test-espresso" }
 androidx-test-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-test-espresso" }


### PR DESCRIPTION
This PR just adds androidx [security-crypto](https://developer.android.com/jetpack/androidx/releases/security) library, we'll need it for the Application Password support in FluxC.

It's being used now in the draft PR https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2586