### PR TITLE
Android 13 Update example module versions

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -15,8 +15,8 @@ plugins {
 
 android {
     defaultConfig {
-        compileSdkVersion(31)
-        minSdkVersion(21)
+        compileSdkVersion(33)
+        minSdkVersion(24)
     }
     lintOptions {
         lintConfig = file("config/lint.xml")


### PR DESCRIPTION
This PR updated compileSdk to 33 and minSdk 24 of example module to fix an issue with Android 13 update

[See here the issue](https://github.com/Automattic/android-dependency-catalog/pull/10#issuecomment-1478872668)