### PR TITLE
Update WordPress-Utils version to 3.6.0

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -82,7 +82,7 @@ wellsql = "1.7.0"
 wiremock = "2.26.3"
 wordpress-aztec = "v1.6.3"
 wordpress-libaddressinput = "0.0.2"
-wordpress-utils = "3.5.0"
+wordpress-utils = "3.6.0"
 zendesk-support = "5.0.8"
 
 [libraries]


### PR DESCRIPTION
This updates WordPress-Utils to `3.6.0`. The new WordPress-Utils version adds a new function, `checkNotificationsPermission` to `PermissionUtils` and doesn't include any other changes.