### PR TITLE
Update wordpress utils version to 3.6.1

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -82,7 +82,7 @@ wellsql = "1.7.0"
 wiremock = "2.26.3"
 wordpress-aztec = "v1.6.3"
 wordpress-libaddressinput = "0.0.2"
-wordpress-utils = "3.6.0"
+wordpress-utils = "3.6.1"
 zendesk-support = "5.0.8"
 
 [libraries]


### PR DESCRIPTION
This updates [wordpress utils to 3.6.1](https://github.com/wordpress-mobile/WordPress-Utils-Android/releases/tag/3.6.1). The new version fixes functions in `PermissionUtils` class.
