### PR TITLE
Adds JDK 17 support for GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ jobs:
       uploadurl: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - uses: actions/checkout@v2
+      - name: Set Up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'corretto'
       - name: Extract Tag
         run: echo "TAG_NAME=${GITHUB_REF#refs/*/}" | xargs >> $GITHUB_ENV
       - name: Create Release


### PR DESCRIPTION
Adds JDK 17 support for GitHub actions following @ParaskP7's suggestion [here](https://github.com/Automattic/android-dependency-catalog/pull/20#issuecomment-1645640193). I admit that I didn't research this at all, but for this specific repository, I think it's better to just test it since if it fails we don't block anyone by it.

Note that I skipped the `cache: gradle` configuration from the suggestion because caching can be tricky and that one I wouldn't be comfortable with adding without understanding how it works.