### PR TITLE
Move JDK 17 setup for GitHub actions to generate-asset step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,6 @@ jobs:
       uploadurl: ${{ steps.create_release.outputs.upload_url }}
     steps:
       - uses: actions/checkout@v2
-      - name: Set Up JDK 17
-        uses: actions/setup-java@v3
-        with:
-          java-version: 17
-          distribution: 'corretto'
       - name: Extract Tag
         run: echo "TAG_NAME=${GITHUB_REF#refs/*/}" | xargs >> $GITHUB_ENV
       - name: Create Release
@@ -36,6 +31,11 @@ jobs:
     needs: [setup]
     steps:
       - uses: actions/checkout@v2
+      - name: Set Up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'corretto'
       - name: Build
         run: ./gradlew :catalog:generateCatalogAsToml
       - name: Upload Artifact to Job


### PR DESCRIPTION
In #22, I accidentally put the JDK17 setup to the `setup` step instead of the `generate-asset` step. This PR moves it to the correct place. Sorry about that!