### PR TITLE
[Nullability Annotations to Java Classes] Add `wordpress-lint` Dependency

### DIFF
--- a/example/settings.gradle.kts
+++ b/example/settings.gradle.kts
@@ -33,6 +33,7 @@ dependencyResolutionManagement {
                 includeModule("com.automattic", "dependency-catalog")
                 includeModule("org.wordpress", "aztec")
                 includeModule("org.wordpress", "libaddressinput.common")
+                includeModule("org.wordpress", "lint")
                 includeModule("org.wordpress", "utils")
                 includeModule("org.wordpress", "wellsql")
                 includeModule("org.wordpress.aztec", "glide-loader")

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -82,6 +82,7 @@ wellsql = "2.0.0"
 wiremock = "2.26.3"
 wordpress-aztec = "v1.6.4"
 wordpress-libaddressinput = "0.0.2"
+wordpress-lint = "2.0.0"
 wordpress-utils = "3.6.1"
 zendesk-support = "5.0.8"
 
@@ -195,6 +196,7 @@ wiremock = { module = "com.github.tomakehurst:wiremock", version.ref = "wiremock
 wordpress-aztec = { module = "org.wordpress:aztec", version.ref = "wordpress-aztec" }
 wordpress-aztec-glide-loader = { module = "org.wordpress.aztec:glide-loader", version.ref = "wordpress-aztec" }
 wordpress-libaddressinput = { module = "org.wordpress:libaddressinput.common", version.ref = "wordpress-libaddressinput" }
+wordpress-lint = { module = "org.wordpress:lint", version.ref = "wordpress-lint" }
 wordpress-utils = { module = "org.wordpress:utils", version.ref = "wordpress-utils" }
 zendesk-support = { module = "com.zendesk:support", version.ref = "zendesk-support" }
 


### PR DESCRIPTION
This PR adds the `org.wordpress:lint` dependency to the catalog ([2.0.0](https://github.com/wordpress-mobile/WordPress-Lint-Android/releases/tag/2.0.0)).

FYI: For more context on why this was done see FluxC's [#2827](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2879) PR.

-----

## To test (via [FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2879)):

1. Based on this [commit](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/2879/commits/1415fb8f6ef91a6c4de224ebb6060b58c3c77726), verify that all the CI checks are successful.
2. Smoke test the `example` app.