### PR TITLE
[Dependency Analysis] Add Android Gradle Plugin

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -11,6 +11,7 @@ plugins {
     alias(libs.plugins.kotlin.detekt).apply(false)
     alias(libs.plugins.kotlin.jvm).apply(false)
     alias(libs.plugins.kotlin.kapt).apply(false)
+    alias(libs.plugins.dependency.analysis).apply(false)
 }
 
 android {

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -45,6 +45,7 @@ automattic-tracks = "2.2.0"
 chrisbanes-photoview = "2.3.0"
 commons-io = "2.11.0"
 dagger = "2.42"
+dependency-analysis = "1.28.0"
 detekt = "1.21.0"
 eventbus = "3.3.1"
 facebook-flipper = "0.138.0"
@@ -203,6 +204,7 @@ zendesk-support = { module = "com.zendesk:support", version.ref = "zendesk-suppo
 [plugins]
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
+dependency-analysis = { id = "com.autonomousapps.dependency-analysis", version.ref = "dependency-analysis" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-android-extensions = { id = "org.jetbrains.kotlin.android.extensions", version.ref = "kotlin" }
 kotlin-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }


### PR DESCRIPTION
Project Thread: paaHJt-6yU-p2
Required By: [FluxC#TODO](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/TODO)

### Description

Adds [Dependency Analysis](https://github.com/autonomousapps/dependency-analysis-gradle-plugin) plugin to be used for the [WordPress-FluxC-Android](https://github.com/wordpress-mobile/WordPress-FluxC-Android) repo (see `Required By`).

### To test ([FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3057)):

1. Based on this [commit](TODO), verify that all the CI checks are successful.
2. Smoke test the `example` app.