### PR TITLE
[Migrate] Kotlin Android Extensions to Kotlin Parcelize

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -7,10 +7,10 @@ plugins {
     alias(libs.plugins.automattic.fetchstyle).apply(false)
     alias(libs.plugins.automattic.publishToS3).apply(false)
     alias(libs.plugins.kotlin.android).apply(false)
-    alias(libs.plugins.kotlin.android.extensions).apply(false)
     alias(libs.plugins.kotlin.detekt).apply(false)
     alias(libs.plugins.kotlin.jvm).apply(false)
     alias(libs.plugins.kotlin.kapt).apply(false)
+    alias(libs.plugins.kotlin.parcelize).apply(false)
 }
 
 android {

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -204,10 +204,10 @@ zendesk-support = { module = "com.zendesk:support", version.ref = "zendesk-suppo
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-kotlin-android-extensions = { id = "org.jetbrains.kotlin.android.extensions", version.ref = "kotlin" }
 kotlin-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 automattic-configure = { id = "com.automattic.android.configure", version.ref = "automattic-configure" }
 automattic-fetchstyle = { id = "com.automattic.android.fetchstyle", version.ref = "automattic-fetchstyle" }
 automattic-publishToS3 = { id = "com.automattic.android.publish-to-s3", version.ref = "automattic-publishToS3" }


### PR DESCRIPTION
Required By: [FluxC#3057](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3057)

### Description

Migrates from the `Kotlin Android Extension` to the `Kotlin Parcelize` plugin.

### To test ([FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3057)):

1. Based on this [commit](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3057/commits/cbb9b687fb5e9a419c6457019c91d51eec0852e1), verify that all the CI checks are successful.
2. Smoke test the `example` app.