### PR TITLE
[Deps] Add Android Keyword to EventBus Library

### DIFF
--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -148,7 +148,7 @@ automattic-tracks = { module = "com.automattic:Automattic-Tracks-Android", versi
 chrisbanes-photoview = { module = "com.github.chrisbanes:PhotoView", version.ref = "chrisbanes-photoview" }
 commons-io = { module = "commons-io:commons-io", version.ref = "commons-io" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
-eventbus = { module = "org.greenrobot:eventbus", version.ref = "eventbus" }
+eventbus-android = { module = "org.greenrobot:eventbus", version.ref = "eventbus" }
 eventbus-java = {group = "org.greenrobot", name = "eventbus-java", version.ref = "eventbus" }
 facebook-flipper = { module = "com.facebook.flipper:flipper", version.ref = "facebook-flipper" }
 facebook-flipper-network-plugin = { module = "com.facebook.flipper:flipper-network-plugin", version.ref = "facebook-flipper" }


### PR DESCRIPTION
### Description

This PR adds the `android` keyword into the main `eventbus` library, for it be later used alongside its corresponding `java` library.

This is done for 2 reasons:
1. To make it explicit that this library is for Android purposes.
2. To differentiate the grouping from `eventbus`.

### Testing Instructions ([FluxC PR](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3100)):

1. Based on this [commit](https://github.com/wordpress-mobile/WordPress-FluxC-Android/pull/3100/commits/95ddea5f657ae19b54f40ec5fbf345621c6bdb72), verify that all the CI checks are successful.
2. Smoke test the `example` app.