### PR TITLE
[Deps] Update Actions Upload Artifact to v4

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build
         run: ./gradlew :catalog:generateCatalogAsToml
       - name: Upload Artifact to Job
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v4
         with:
           name: libs.versions.toml
           path: catalog/build/version-catalog/libs.versions.toml


### PR DESCRIPTION
This PR updates the Actions [upload-artifact](https://github.com/actions/upload-artifact) to v4.

This is done because GitHub Actions start failing during the 'generate-asset' step with the below error message ([example](https://github.com/Automattic/android-dependency-catalog/actions/runs/11009523143/job/30569373057)):

```
Error: This request has been automatically failed because it uses a deprecated version of
`actions/upload-artifact: v1`. Learn more: https://github.blog/changelog/
2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/
```